### PR TITLE
fix(watch): trim tl;dr and do not justify it on mobile

### DIFF
--- a/src/app/watch/watchResource.tsx
+++ b/src/app/watch/watchResource.tsx
@@ -34,7 +34,8 @@ const ResourceType: FC<{ type: WatchResource['type'] }> = ({ type }) => {
 
 const WatchResource: FC<Props> = ({ resource }) => {
   const { title, tldr, source, subSource, url, type } = resource
-  const tldrWithDot = tldr?.endsWith('.') ? tldr : `${tldr}.`
+  const trimedTldr = tldr?.trim()
+  const tldrWithDot = trimedTldr?.endsWith('.') ? trimedTldr : `${trimedTldr}.`
 
   return (
     <a
@@ -48,7 +49,7 @@ const WatchResource: FC<Props> = ({ resource }) => {
           {title}
         </h5>
         <div className="grid grid-cols-6 gap-4 font-normal text-gray-700 dark:text-gray-400">
-          <div className="col-span-6 line-clamp-4 text-justify font-mono text-xs md:line-clamp-6">
+          <div className="col-span-6 line-clamp-4 text-left font-mono text-xs md:line-clamp-6 md:text-justify">
             {tldrWithDot}
           </div>
         </div>


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->

I had issues with `watchResources` whose `tl;dr` was ending by a `. ` causing the app to add a `.` thus displaying a `. .`.

Moreover, there is a bug on Safari on mobile when justifying a text on which a `line-clamp` (multi-line ellipsis) was applied.

## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->

I made sure to `trim()` the `tl;dr` before checking if a closing `.` is necessary.

I also make sure to justify the `tl;dr` on `md` breakpoint only.