### PR TITLE
fix(theme): avoid crash on switching back to system theme

### DIFF
--- a/src/components/theme-switch/ThemeSwitch.tsx
+++ b/src/components/theme-switch/ThemeSwitch.tsx
@@ -30,7 +30,7 @@ const menuItemIcon = tv({
 
 const ThemeSwitch: FC = () => {
   const [isSystemDark, setIsSystemDark] = useState(false)
-  const [theme, setTheme] = useLocalStorage<string | undefined>(
+  const [theme, setTheme, removeTheme] = useLocalStorage<string | undefined>(
     'theme',
     undefined,
   )
@@ -57,6 +57,7 @@ const ThemeSwitch: FC = () => {
   }, [])
 
   useEffect(() => {
+    console.log('📍 theme', theme)
     // If the theme is `dark` or `system` (and system theme is `dark`)
     if (theme === 'dark' || (theme === undefined && isSystemDark)) {
       document.documentElement.classList.add('dark')
@@ -69,7 +70,7 @@ const ThemeSwitch: FC = () => {
   const handleThemeChange = (newTheme: string): void => {
     // In case the `system` theme is selected, remove it from the LocalStorage
     if (newTheme === 'system') {
-      setTheme(undefined)
+      removeTheme()
       return
     }
 
@@ -123,7 +124,6 @@ const ThemeSwitch: FC = () => {
                 className={menuItem({ active: theme === undefined })}
                 onClick={() => {
                   handleThemeChange('system')
-                  close()
                 }}
               >
                 <HiOutlineDesktopComputer className={menuItemIcon()} /> System


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->

There was an issue with the `ThemeSwitch` component causing the application to sometimes crash when switching back to _system_ theme.

## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->

I actually remove the entry from the `LocalStorage` now and removed the unnecessary `close()` call to close the popup.