### PR TITLE
fix(misc): fine-tune some components in light mode on mobile

### DIFF
--- a/src/components/home/2-about-me/AboutMe.tsx
+++ b/src/components/home/2-about-me/AboutMe.tsx
@@ -167,7 +167,7 @@ const AboutMe: FC = () => {
             <div className="absolute h-full w-48 overflow-hidden rounded">
               <Image
                 src="/img/profile.jpg"
-                className="rounded-lg object-contain"
+                className="rounded-lg object-cover"
                 alt="Portfolio profile"
                 fill
               />

--- a/src/components/home/3-work-experience/WorkExperienceDetails.tsx
+++ b/src/components/home/3-work-experience/WorkExperienceDetails.tsx
@@ -22,7 +22,7 @@ const WorkExperienceDetails: FC<Props> = ({ experience }) => {
             )}
           </span>
 
-          <span className="text-sm tracking-wide text-gray-100 sm:text-lg">
+          <span className="text-sm tracking-wide text-gray-600 dark:text-gray-100 sm:text-lg">
             {experience.icon}
           </span>
         </div>

--- a/src/components/home/3-work-experience/components/WorkExperienceTabs.tsx
+++ b/src/components/home/3-work-experience/components/WorkExperienceTabs.tsx
@@ -85,7 +85,7 @@ const WorkExperienceTabs: FC<ExperiencesTabsProps> = ({
           })}
         </div>
 
-        <div className="block h-0.5 rounded bg-gray-500 md:hidden">
+        <div className="block h-0.5 rounded bg-gray-200 dark:bg-gray-500 md:hidden">
           <motion.div
             animate={{ x: barAbovePosition }}
             className="h-0.5 w-[128px] rounded bg-primary"


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->

In this PR, I fixed some misc points on mobile view in light mode.


## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->

Here are the changes:

- Make the profile image `cover`
- Update the work experience icon colour which was always white even in light
- Lighten the bar holder on the work experience tabs
