### PR TITLE
feat(watch): add button to show more content on truncated `tl;dr`

### DIFF
--- a/src/components/theme-switch/ThemeSwitch.tsx
+++ b/src/components/theme-switch/ThemeSwitch.tsx
@@ -57,7 +57,6 @@ const ThemeSwitch: FC = () => {
   }, [])
 
   useEffect(() => {
-    console.log('📍 theme', theme)
     // If the theme is `dark` or `system` (and system theme is `dark`)
     if (theme === 'dark' || (theme === undefined && isSystemDark)) {
       document.documentElement.classList.add('dark')


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->

In this PR, I added a `Show more...` button enabling to display the whole content on the watch resources having a truncated `tl;dr`.

## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->

I used a `useLayoutEffect` for that purpose to determine with JavaScript if the element is truncated with CSS.

I also added a `title` on the resource heading in case it is truncated too.