### PR TITLE
fix(media-around): hover in blue color on dark mode

### DIFF
--- a/src/components/home/social-media-around/SocialMediaAround.tsx
+++ b/src/components/home/social-media-around/SocialMediaAround.tsx
@@ -12,7 +12,7 @@ const IconClickableWithAnimation: FC<Props> = ({ href, Icon }) => {
   return (
     <motion.div whileHover={{ y: -3, transition: { duration: 0.1 } }}>
       <a href={href} target="_blank" rel="noreferrer">
-        <Icon className="size-6 fill-current text-gray-500 hover:cursor-pointer hover:text-primary dark:text-gray-400" />
+        <Icon className="size-6 fill-current text-gray-500 hover:cursor-pointer hover:text-primary dark:text-gray-400 dark:hover:text-primary" />
       </a>
     </motion.div>
   )
@@ -64,7 +64,7 @@ export default function SocialMediaEmail() {
               rel="noreferrer"
               className="hover:no-underline"
             >
-              <span className="font-header tracking-wider text-gray-500 hover:cursor-pointer hover:text-primary dark:text-gray-400">
+              <span className="font-header tracking-wider text-gray-500 hover:cursor-pointer hover:text-primary dark:text-gray-400 dark:hover:text-primary">
                 darchen.gautier<span className="text-primary">@</span>gmail
                 <span className="text-primary">.</span>com
               </span>


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->

The icons and links in `SocialMediaAround` did not change color on hover in dark mode.

## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->
