### PR TITLE
chore(lint): fix `eslint-plugin-unused-imports` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-tailwindcss": "3.17.4",
-    "eslint-plugin-unused-imports": "^4.0.0",
+    "eslint-plugin-unused-imports": "4.0.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.7",
     "postcss": "^8.4.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: 3.17.4
         version: 3.17.4(tailwindcss@3.4.9)
       eslint-plugin-unused-imports:
-        specifier: ^4.0.0
-        version: 4.1.2(eslint@8.57.0)
+        specifier: 4.0.1
+        version: 4.0.1(eslint@8.57.0)
       husky:
         specifier: ^9.0.11
         version: 9.1.4
@@ -1199,14 +1199,19 @@ packages:
     peerDependencies:
       tailwindcss: ^3.4.0
 
-  eslint-plugin-unused-imports@4.1.2:
-    resolution: {integrity: sha512-A/Ypb0DQlDEzIbcoAv87NpLLcG3iwlE0gBEpS9Ud/62v2v3CoO15lZ/WfGyo2Wq7YraWJ2aE0TeHgJcpor6KQQ==}
+  eslint-plugin-unused-imports@4.0.1:
+    resolution: {integrity: sha512-rax76s05z64uQgG9YXsWFmXrgjkaK79AvfeAWiSxhPP6RVGxeRaj4+2u+wxxu/mDy2pmJoOy1QTOEALMia2xGQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
-      eslint: ^9.0.0 || ^8.0.0
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0
+      eslint: ^9.0.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
+
+  eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -4043,9 +4048,12 @@ snapshots:
       postcss: 8.4.41
       tailwindcss: 3.4.9
 
-  eslint-plugin-unused-imports@4.1.2(eslint@8.57.0):
+  eslint-plugin-unused-imports@4.0.1(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
+      eslint-rule-composer: 0.3.0
+
+  eslint-rule-composer@0.3.0: {}
 
   eslint-scope@7.2.2:
     dependencies:


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->
In this PR, I fixed a lint issue added by a Renovate auto-merged PR.


## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->

I fixed the `eslint-plugin-unused-imports` version, since the auto-merged version was expecting `eslint@9` which is currently not supported on Next.