### PR TITLE
fix(watch): fix broken styling of shiny resources on 3xl screens

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/app/watch/components/watchResource/watchResource.tsx
+++ b/src/app/watch/components/watchResource/watchResource.tsx
@@ -163,7 +163,7 @@ const WatchResource: FC<Props> = ({ resource, query, truncate = true }) => {
         href={url}
         target="_blank"
         rel="noreferrer"
-        className="relative z-10 flex w-full max-w-sm flex-col justify-between overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
+        className="relative z-10 flex w-full flex-col justify-between overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
       >
         <div>
           <h5 className={resourceTitle({ truncate })} title={title}>


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe the problem or feature in functional terms by providing a short description. -->

The watch resources card was broken in case of `shiny` on very large screens.

## 🧠 Approach

<!-- Explain how these changes solve the problem. Give as much detail as possible. -->

I removed the constraint on the width on the card itself.